### PR TITLE
[WIP] nspawn: Add --system-call-filter option

### DIFF
--- a/src/nspawn/nspawn-seccomp.c
+++ b/src/nspawn/nspawn-seccomp.c
@@ -36,104 +36,162 @@
 
 #ifdef HAVE_SECCOMP
 
-static int seccomp_add_default_syscall_filter(
-                scmp_filter_ctx ctx,
-                uint32_t arch,
-                uint64_t cap_list_retain) {
+const SyscallFilterSet default_syscall_filter = {
+        .name = "@nspawn_default",
+        .help = "System calls filter for systemd-nspawn",
+        .value =
+        "_sysctl\0"
+        "add_key\0"
+        "afs_syscall\0"
+        "bdflush\0"
+        "bpf\0"
+        "break\0"
+        "create_module\0"
+        "ftime\0"
+        "get_kernel_syms\0"
+        "getpmsg\0"
+        "gtty\0"
+        "kexec_file_load\0"
+        "kexec_load\0"
+        "keyctl\0"
+        "lock\0"
+        "lookup_dcookie\0"
+        "mpx\0"
+        "ngsservctl\0"
+        "open_by_handle_at\0"
+        "perf_event_open\0"
+        "prof\0"
+        "profil\0"
+        "putpmsg\0"
+        "query_module\0"
+        "quotactl\0"
+        "request_key\0"
+        "security\0"
+        "sgetmask\0"
+        "ssetmask\0"
+        "stty\0"
+        "swapoff\0"
+        "swapon\0"
+        "sysfs\0"
+        "tuxcall\0"
+        "ulimit\0"
+        "uselib\0"
+        "ustat\0"
+        "vserver\0"
+};
 
-        static const struct {
-                uint64_t capability;
-                int syscall_num;
-        } blacklist[] = {
-                { 0,              SCMP_SYS(_sysctl)             }, /* obsolete syscall */
-                { 0,              SCMP_SYS(add_key)             }, /* keyring is not namespaced */
-                { 0,              SCMP_SYS(afs_syscall)         }, /* obsolete syscall */
-                { 0,              SCMP_SYS(bdflush)             },
-#ifdef __NR_bpf
-                { 0,              SCMP_SYS(bpf)                 },
-#endif
-                { 0,              SCMP_SYS(break)               }, /* obsolete syscall */
-                { 0,              SCMP_SYS(create_module)       }, /* obsolete syscall */
-                { 0,              SCMP_SYS(ftime)               }, /* obsolete syscall */
-                { 0,              SCMP_SYS(get_kernel_syms)     }, /* obsolete syscall */
-                { 0,              SCMP_SYS(getpmsg)             }, /* obsolete syscall */
-                { 0,              SCMP_SYS(gtty)                }, /* obsolete syscall */
-#ifdef __NR_kexec_file_load
-                { 0,              SCMP_SYS(kexec_file_load)     },
-#endif
-                { 0,              SCMP_SYS(kexec_load)          },
-                { 0,              SCMP_SYS(keyctl)              }, /* keyring is not namespaced */
-                { 0,              SCMP_SYS(lock)                }, /* obsolete syscall */
-                { 0,              SCMP_SYS(lookup_dcookie)      },
-                { 0,              SCMP_SYS(mpx)                 }, /* obsolete syscall */
-                { 0,              SCMP_SYS(nfsservctl)          }, /* obsolete syscall */
-                { 0,              SCMP_SYS(open_by_handle_at)   },
-                { 0,              SCMP_SYS(perf_event_open)     },
-                { 0,              SCMP_SYS(prof)                }, /* obsolete syscall */
-                { 0,              SCMP_SYS(profil)              }, /* obsolete syscall */
-                { 0,              SCMP_SYS(putpmsg)             }, /* obsolete syscall */
-                { 0,              SCMP_SYS(query_module)        }, /* obsolete syscall */
-                { 0,              SCMP_SYS(quotactl)            },
-                { 0,              SCMP_SYS(request_key)         }, /* keyring is not namespaced */
-                { 0,              SCMP_SYS(security)            }, /* obsolete syscall */
-                { 0,              SCMP_SYS(sgetmask)            }, /* obsolete syscall */
-                { 0,              SCMP_SYS(ssetmask)            }, /* obsolete syscall */
-                { 0,              SCMP_SYS(stty)                }, /* obsolete syscall */
-                { 0,              SCMP_SYS(swapoff)             },
-                { 0,              SCMP_SYS(swapon)              },
-                { 0,              SCMP_SYS(sysfs)               }, /* obsolete syscall */
-                { 0,              SCMP_SYS(tuxcall)             }, /* obsolete syscall */
-                { 0,              SCMP_SYS(ulimit)              }, /* obsolete syscall */
-                { 0,              SCMP_SYS(uselib)              }, /* obsolete syscall */
-                { 0,              SCMP_SYS(ustat)               }, /* obsolete syscall */
-                { 0,              SCMP_SYS(vserver)             }, /* obsolete syscall */
-                { CAP_SYSLOG,     SCMP_SYS(syslog)              },
-                { CAP_SYS_MODULE, SCMP_SYS(delete_module)       },
-                { CAP_SYS_MODULE, SCMP_SYS(finit_module)        },
-                { CAP_SYS_MODULE, SCMP_SYS(init_module)         },
-                { CAP_SYS_PACCT,  SCMP_SYS(acct)                },
-                { CAP_SYS_PTRACE, SCMP_SYS(process_vm_readv)    },
-                { CAP_SYS_PTRACE, SCMP_SYS(process_vm_writev)   },
-                { CAP_SYS_PTRACE, SCMP_SYS(ptrace)              },
-                { CAP_SYS_RAWIO,  SCMP_SYS(ioperm)              },
-                { CAP_SYS_RAWIO,  SCMP_SYS(iopl)                },
-                { CAP_SYS_RAWIO,  SCMP_SYS(pciconfig_iobase)    },
-                { CAP_SYS_RAWIO,  SCMP_SYS(pciconfig_read)      },
-                { CAP_SYS_RAWIO,  SCMP_SYS(pciconfig_write)     },
+const SyscallFilterSetCap syscall_filter_caps_sets[_SYSCALL_FILTER_CAPS_SET_MAX] = {
+        [SYSCALL_FILTER_SET_CAP_SYSLOG] = {
+                .filter = {
+                        .name = "@nspawn_cap_syslog",
+                        .help = "System calls to be disabled when CAP_SYSLOG is not set",
+                        .value =
+                        "syslog\0"
+                },
+                .capability = CAP_SYSLOG
+        },
+        [SYSCALL_FILTER_SET_CAP_SYS_MODULE] = {
+                .filter = {
+                        .name = "@nspawn_cap_sys_module",
+                        .help = "System calls to be disabled when CAP_SYS_MODULE is not set",
+                        .value =
+                        "delete_module\0"
+                        "finit_module\0"
+                        "init_module\0"
+                },
+                .capability = CAP_SYS_MODULE
+        },
+        [SYSCALL_FILTER_SET_CAP_SYS_PACCT] = {
+                .filter = {
+                        .name = "@nspawn_cap_sys_pacct",
+                        .help = "System calls to be disabled when CAP_SYS_PACCT is not set",
+                        .value =
+                        "acct\0"
+                },
+                .capability = CAP_SYS_PACCT
+        },
+        [SYSCALL_FILTER_SET_CAP_SYS_PTRACE] = {
+                .filter = {
+                        .name = "@nspawn_cap_sys_ptrace",
+                        .help = "System calls to be disabled when CAP_SYS_PTRACE is not set",
+                        .value =
+                        "process_vm_readv\0"
+                        "process_vm_writev\0"
+                        "ptrace\0"
+                },
+                .capability = CAP_SYS_PTRACE
+        },
+        [SYSCALL_FILTER_SET_CAP_SYS_RAWIO] = {
+                .filter = {
+                        .name = "@nspawn_cap_sys_rawio",
+                        .help = "System calls to be disabled when CAP_SYS_RAWIO is not set",
+                        .value =
+                        "ioperm\0"
+                        "iopl\0"
+                        "pciconfig_iobase\0"
+                        "pciconfig_read\0"
+                        "pciconfig_write\0"
 #ifdef __NR_s390_pci_mmio_read
-                { CAP_SYS_RAWIO,  SCMP_SYS(s390_pci_mmio_read)  },
+                        "s390_pci_mmio_read\0"
 #endif
 #ifdef __NR_s390_pci_mmio_write
-                { CAP_SYS_RAWIO,  SCMP_SYS(s390_pci_mmio_write) },
+                        "s390_pci_mmio_write\0"
 #endif
-                { CAP_SYS_TIME,   SCMP_SYS(adjtimex)            },
-                { CAP_SYS_TIME,   SCMP_SYS(clock_adjtime)       },
-                { CAP_SYS_TIME,   SCMP_SYS(clock_settime)       },
-                { CAP_SYS_TIME,   SCMP_SYS(settimeofday)        },
-                { CAP_SYS_TIME,   SCMP_SYS(stime)               },
-        };
+                },
+                .capability = CAP_SYS_RAWIO
+        },
+        [SYSCALL_FILTER_SET_CAP_SYS_TIME] = {
+                .filter = {
+                        .name = "@nspawn_cap_sys_time",
+                        .help = "System calls to be disabled when CAP_SYS_TIME is not set",
+                        .value =
+                        "adjtimex\0"
+                        "clock_adjtime\0"
+                        "clock_settime\0"
+                        "settimeofday\0"
+                        "stime\0"
+                },
+                .capability = CAP_SYS_TIME
+        },
+};
+
+static int seccomp_add_syscall_filters(
+                scmp_filter_ctx ctx,
+                uint32_t arch,
+                uint64_t cap_list_retain,
+                const char *system_call_filter) {
         unsigned i;
-        int r, c = 0;
+        int r;
 
-        for (i = 0; i < ELEMENTSOF(blacklist); i++) {
-                if (blacklist[i].capability != 0 && (cap_list_retain & (1ULL << blacklist[i].capability)))
-                        continue;
+        if (system_call_filter != NULL) {
+                SyscallFilterSet syscall_filter = {
+                        .name = "@nspawn_custom",
+                        .help = "",
+                        .value = system_call_filter
+                };
 
-                r = seccomp_rule_add_exact(ctx, SCMP_ACT_ERRNO(EPERM), blacklist[i].syscall_num, 0);
-                if (r < 0) {
-                        /* If the system call is not known on this architecture, then that's fine, let's ignore it */
-                        _cleanup_free_ char *n = NULL;
+                r = seccomp_add_syscall_filter_set(ctx, SCMP_ACT_ERRNO(EPERM), &syscall_filter, 0);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to add rules from the command line, ignoring: %m");
+        } else {
+                r = seccomp_add_syscall_filter_set(ctx, SCMP_ACT_ERRNO(EPERM), &default_syscall_filter, 0);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to add default filter set, ignoring: %m");
 
-                        n = seccomp_syscall_resolve_num_arch(arch, blacklist[i].syscall_num);
-                        log_debug_errno(r, "Failed to add rule for system call %s, ignoring: %m", strna(n));
-                } else
-                        c++;
+                for (i = 0; i < _SYSCALL_FILTER_CAPS_SET_MAX; i++) {
+                        if (cap_list_retain & (1ULL << syscall_filter_caps_sets[i].capability))
+                                continue;
+
+                        r = seccomp_add_syscall_filter_set(ctx, SCMP_ACT_ERRNO(EPERM), &syscall_filter_caps_sets[i].filter, 0);
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to add rules for capability, ignoring: %m");
+                }
         }
 
-        return c;
+        return 0;
 }
 
-int setup_seccomp(uint64_t cap_list_retain) {
+int setup_seccomp(uint64_t cap_list_retain, const char *system_call_filter) {
         uint32_t arch;
         int r;
 
@@ -152,7 +210,7 @@ int setup_seccomp(uint64_t cap_list_retain) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to allocate seccomp object: %m");
 
-                n = seccomp_add_default_syscall_filter(seccomp, arch, cap_list_retain);
+                n = seccomp_add_syscall_filters(seccomp, arch, cap_list_retain, system_call_filter);
                 if (n < 0)
                         return n;
 

--- a/src/nspawn/nspawn-seccomp.h
+++ b/src/nspawn/nspawn-seccomp.h
@@ -21,4 +21,21 @@
 
 #include <sys/types.h>
 
-int setup_seccomp(uint64_t cap_list_retain);
+#include "seccomp-util.h"
+
+typedef struct SyscallFilterSetCap {
+        SyscallFilterSet filter;
+        int capability;
+} SyscallFilterSetCap;
+
+enum {
+        SYSCALL_FILTER_SET_CAP_SYSLOG,
+        SYSCALL_FILTER_SET_CAP_SYS_MODULE,
+        SYSCALL_FILTER_SET_CAP_SYS_PACCT,
+        SYSCALL_FILTER_SET_CAP_SYS_PTRACE,
+        SYSCALL_FILTER_SET_CAP_SYS_RAWIO,
+        SYSCALL_FILTER_SET_CAP_SYS_TIME,
+        _SYSCALL_FILTER_CAPS_SET_MAX
+};
+
+int setup_seccomp(uint64_t cap_list_retain, const char *system_call_filter);

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -659,7 +659,7 @@ const SyscallFilterSet *syscall_filter_set_find(const char *name) {
         return NULL;
 }
 
-static int seccomp_add_syscall_filter_set(
+int seccomp_add_syscall_filter_set(
                 scmp_filter_ctx seccomp,
                 uint32_t default_action,
                 const SyscallFilterSet *set,

--- a/src/shared/seccomp-util.h
+++ b/src/shared/seccomp-util.h
@@ -66,6 +66,7 @@ extern const SyscallFilterSet syscall_filter_sets[];
 
 const SyscallFilterSet *syscall_filter_set_find(const char *name);
 
+int seccomp_add_syscall_filter_set(scmp_filter_ctx seccomp, uint32_t default_action, const SyscallFilterSet *set, uint32_t action);
 int seccomp_load_syscall_filter_set(uint32_t default_action, const SyscallFilterSet *set, uint32_t action);
 int seccomp_load_syscall_filter_set_raw(uint32_t default_action, Set* set, uint32_t action);
 


### PR DESCRIPTION
Just showing my idea and progress, not ready for submitting upstream yet.

---

The --system-call-filter option allows to override the default
seccomp filter with the list predefined by the user.

Fixes #5163